### PR TITLE
Fix: remove unnecessary assertion for mask shape and add mask specification in API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ sparse_attn_output = sparse_sageattn(
         is_causal=False, 
         tensor_layout="HND")
 ```
-* `q, k, v` are in `FP16/BF16` with the shape of `(batch_size, head_num, seq_len, head_dim)` when using the default `tenso_layout`
-* `mask_id` is a **block mask** to specify whether the corresponding block in the attention map should be calculated (**`1` for calculating and `0` for skipped**). The default value is `None`, which will perform full SageAttention V1. Currently, we only support the block size of (128, 64). For example, for an attention map (512x512) below, we can set `mask_id` as:
+* `q, k, v` are in `FP16/BF16` with the shape of `(batch_size, head_num, seq_len, head_dim)` when using the default `tensor_layout`
+* `mask_id` is a **block mask** to specify whether the corresponding block in the attention map should be calculated (**`1` for calculating and `0` for skipped**). `mask_id` is of shape `(batch_size, num_qo_heads, qo_seq_len // BLOCK_M, kv_seq_len // BLOCK_N)`, which means that we can specify a block-level attention mask for each attention head. The default value is `None`, which will perform full SageAttention V1. Currently, we only support the block size of (128, 64). For example, for an attention map (512x512) below, we can set `mask_id` as:
 
 ```python
 mask_id = torch.tensor([

--- a/sparse_sageattn/sparse_int8_attn.py
+++ b/sparse_sageattn/sparse_int8_attn.py
@@ -139,7 +139,8 @@ def forward(q, k, k_block_id, v, q_scale, k_scale, is_causal=False, tensor_layou
     else:
         raise ValueError(f"tensor_layout {tensor_layout} not supported")
     
-    assert qo_len == kv_len, "qo_len and kv_len must be equal for causal attention"
+    if is_causal:
+        assert qo_len == kv_len, "qo_len and kv_len must be equal for causal attention"
 
     HEAD_DIM_K = head_dim
     num_kv_groups = h_qo // h_kv


### PR DESCRIPTION
Hi! I tried to integrate sage attention in one of our recent sparse attention work but came across the aforementioned issues. So I managed to do some minor change. Thanks for your attention.